### PR TITLE
feat : 검색량과 거리를 통한 월드컵 가게 선정

### DIFF
--- a/src/main/java/com/dnd/mountclim/domain/controller/KakaoController.java
+++ b/src/main/java/com/dnd/mountclim/domain/controller/KakaoController.java
@@ -44,21 +44,10 @@ public class KakaoController {
 		@RequestParam(name = "radius", required = true) String radius,
 		@RequestParam(name = "round", required = true) String round) throws Exception {
 
-		RectanglePoints rectanglePoints = pointService.getRectanglePoints(Double.parseDouble(latitude), Double.parseDouble(longitude), Double.parseDouble(radius)); // km 기준 입니다.
+		RectanglePoints rectanglePoints = pointService.getRectanglePoints(Double.parseDouble(latitude), Double.parseDouble(longitude), Double.parseDouble(radius) * 0.001); // km 기준 입니다.
 
-		System.out.println("=== test1 ===");
-		for (LocationPoint lp : rectanglePoints.getRectanglePoints()){
-			System.out.println("lat : " + lp.getLatitude() + ", lng : " + lp.getLongitude());
-		}
-		List<RectanglePoints> listRectanglePoints = pointService.getRectanglePoints(rectanglePoints, Double.parseDouble(radius) / 2);
+		List<RectanglePoints> listRectanglePoints = pointService.getRectanglePoints(rectanglePoints, Double.parseDouble(radius) * 0.001 / 2);
 
-		System.out.println("=== test ===");
-		for(RectanglePoints rp : listRectanglePoints){
-			for(LocationPoint lp : rp.getRectanglePoints()){
-				System.out.println("lat : " + lp.getLatitude() + ", lng : " + lp.getLongitude());
-			}
-		}
-		// TODO 위도 경도는 위에처럼 꺼내서 쓰시면 되고, radius는 'radius = radius / 4;'해서 탐색해야 합니다.
-		return haeyongService.kakaoApi(food, latitude, longitude, radius, round);
+		return haeyongService.kakaoApi(food, listRectanglePoints, latitude, longitude, radius, round);
 	}
 }

--- a/src/main/java/com/dnd/mountclim/domain/dto/NaverResponseDto.java
+++ b/src/main/java/com/dnd/mountclim/domain/dto/NaverResponseDto.java
@@ -1,0 +1,45 @@
+package com.dnd.mountclim.domain.dto;
+
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.Data;
+
+import java.util.List;
+
+@Data
+@ApiModel(value = "네이버 API 정보", description = "검색 개수, 제목, link등을 가진 Dto Class")
+public class NaverResponseDto {
+
+    @ApiModelProperty(value = "검색 결과를 생성한 시간", example = "Fri, 19 Aug 2022 19:53:22 +0900")
+    public String lastBuildDate;
+
+    @ApiModelProperty(value = "검색 결과 문서의 총 개수", example = "4326")
+    public int total;
+
+    @ApiModelProperty(value = "문서의 시작점", example = "1")
+    public int start;
+
+    @ApiModelProperty(value = "검색된 검색 결과의 개수", example = "10")
+    public int display;
+
+
+    public List<Item> items;
+
+    @Data
+    public static class Item {
+        @ApiModelProperty(value = "문서의 제목", example = "수원역삼겹살 고기 구워주는 <b>마장동김씨</b> 수원역점")
+        public String title;
+        @ApiModelProperty(value = "문서의 하이퍼텍스트 link", example = "https://blog.naver.com/kurohana?Redirect=Log&logNo=222842437086")
+        public String link;
+        @ApiModelProperty(value = "문서의 내용을 요약한 페시지 정보", example = "수원역삼겹살 <b>마장동 김씨</b>는 약 10년간의 요식업 경험을 토대로 수많은 연구와 노력 끝에 만들어진... 저희는 2인 추천 마장동 모둠 소를 주문했습니다. 모둠 소 메뉴는 통삼겹살 * 눈꽃목살 400g + 칼집 껍데기... ")
+        public String description;
+        @ApiModelProperty(value = "블로거 이름", example = "클로하 HOME : Daily Log")
+        public String bloggername;
+        @ApiModelProperty(value = "블로거의 하이퍼텍스트 link", example = "https://blog.naver.com/kurohana")
+        public String bloggerlink;
+        @ApiModelProperty(value = "블로그 포스트를 작성한 날짜", example = "20220808")
+        public String postdata;
+
+    }
+
+}

--- a/src/main/java/com/dnd/mountclim/domain/service/DistanceService.java
+++ b/src/main/java/com/dnd/mountclim/domain/service/DistanceService.java
@@ -1,0 +1,36 @@
+package com.dnd.mountclim.domain.service;
+
+import org.springframework.stereotype.Service;
+
+@Service
+public class DistanceService {
+
+    public double distance(double lat1, double lon1, double lat2, double lon2, String unit) {
+
+        double theta = lon1 - lon2;
+        double dist = Math.sin(deg2rad(lat1)) * Math.sin(deg2rad(lat2)) + Math.cos(deg2rad(lat1)) * Math.cos(deg2rad(lat2)) * Math.cos(deg2rad(theta));
+
+        dist = Math.acos(dist);
+        dist = rad2deg(dist);
+        dist = dist * 60 * 1.1515;
+
+        if (unit == "kilometer") {
+            dist = dist * 1.609344;
+        } else if(unit == "meter"){
+            dist = dist * 1609.344;
+        }
+
+        return (dist);
+    }
+
+
+    // This function converts decimal degrees to radians
+    private static double deg2rad(double deg) {
+        return (deg * Math.PI / 180.0);
+    }
+
+    // This function converts radians to decimal degrees
+    private static double rad2deg(double rad) {
+        return (rad * 180 / Math.PI);
+    }
+}

--- a/src/main/java/com/dnd/mountclim/domain/service/KakaoService.java
+++ b/src/main/java/com/dnd/mountclim/domain/service/KakaoService.java
@@ -1,10 +1,12 @@
 package com.dnd.mountclim.domain.service;
 
-import java.util.ArrayList;
-import java.util.Comparator;
-import java.util.List;
-import java.util.stream.Collectors;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 
+import com.dnd.mountclim.domain.dto.LocationPoint;
+import com.dnd.mountclim.domain.dto.RectanglePoints;
+import com.dnd.mountclim.domain.util.DeduplicationUtils;
+import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -19,19 +21,22 @@ import com.dnd.mountclim.domain.dto.KakaoResponseDto;
 import com.dnd.mountclim.domain.dto.KakaoResponseDto.Document;
 
 @Service
+@RequiredArgsConstructor
 public class KakaoService {
-	
-	@Autowired
-	private DinignCodeService dinignCodeService;
+
+	private final DistanceService distanceService;
+
+	private final NaverService naverService;
 	
 	@Value("${kakao.api.key}")
 	private String KAKAO_APIKEY;	
 	
 	KakaoResponseDto newKakaoResponseDto;
 	List<Document> newDocuments;
-	
+
 	public ResponseEntity<KakaoResponseDto> kakaoApi(
 		String food,
+		List<RectanglePoints> listRectanglePoints,
 		String latitude,
 		String longitude,
 		String radius,
@@ -43,90 +48,113 @@ public class KakaoService {
 		newDocuments = new ArrayList<>();
 		try {
 			HttpEntity<String> entity = new HttpEntity<String>(headers);
-			
+
+			// FIXME 16분할 했으므로, divisionRadius는 'divisionRadius는 = radius / 4;'로 탐색, 분할 개수 바뀌면 수정해야함.
+			String divisionRadius = String.valueOf(Double.parseDouble(radius) / 4);
+
 			int page = 1;
-			while(true) {	
-				headers.set("Authorization", "KakaoAK " + KAKAO_APIKEY);
-				String apiURL = "https://dapi.kakao.com/v2/local/search/category.JSON?"
-						+ "&category_group_code=" + "FD6"
-						+ "&x=" + longitude
-						+ "&y=" + latitude
-						+ "&radius=" + radius
-						+ "&page=" + page;
-				
-				ResponseEntity<KakaoResponseDto> responseEntity = restTemplate.exchange(apiURL, HttpMethod.GET, entity, KakaoResponseDto.class);
-				kakaoResponseDto = responseEntity.getBody();	
-				
-				if(kakaoResponseDto.meta.is_end) {
-					this.foodClassification(kakaoResponseDto, food); 
-					break;
-				} else {
-					this.foodClassification(kakaoResponseDto, food); 
-					page++;
+			for(RectanglePoints rp : listRectanglePoints) {
+				for (LocationPoint lp : rp.getRectanglePoints()) {
+
+					while (true) {
+						headers.set("Authorization", "KakaoAK " + KAKAO_APIKEY);
+						String apiURL = "https://dapi.kakao.com/v2/local/search/category.JSON?"
+								+ "&category_group_code=" + "FD6"
+								+ "&x=" + lp.getLongitude()
+								+ "&y=" + lp.getLatitude()
+								+ "&radius=" + divisionRadius
+								+ "&page=" + page;
+
+						ResponseEntity<KakaoResponseDto> responseEntity = restTemplate.exchange(apiURL, HttpMethod.GET, entity, KakaoResponseDto.class);
+						kakaoResponseDto = responseEntity.getBody();
+
+						if (kakaoResponseDto.meta.is_end) {
+							this.foodClassification(kakaoResponseDto, food);
+							break;
+						} else {
+							this.foodClassification(kakaoResponseDto, food);
+							page++;
+						}
+					}
 				}
 			}
-			// 제일 많은 리뷰 순서대로 줄 세우고 round 갯수만큼 뽑아내기
-			List<Document> orderByDocument = new ArrayList<>();
-			if(newDocuments.size() > 0) {
-				newDocuments = newDocuments.stream().filter(x -> x.review != null).sorted(Comparator.comparing(Document::getReview).reversed()).collect(Collectors.toList());					
-				int max = 0;
-				if(newDocuments.size() >= Integer.parseInt(round)) {
-					max = Integer.parseInt(round);
-				} else {
-					max = newDocuments.size();
-				}
-				for(int i = 0; i < max; i++) {
-					orderByDocument.add(newDocuments.get(i));
-				}
+
+			// 중복제거
+			List<Document> distinctNewDocuments = DeduplicationUtils.deduplication(newDocuments, Document::getId);
+			// 거리 업데이트 // 분할된 지점으로부터 거리가 나오기 때문에, 원위치로부터 거리 다시 계산
+			for(Document d : distinctNewDocuments){
+				double distanceMeter = distanceService.distance(Double.parseDouble(d.getY()), Double.parseDouble(d.getX()), Double.parseDouble(latitude), Double.parseDouble(longitude), "meter");
+				d.setDistance(String.valueOf(distanceMeter));
 			}
-			newKakaoResponseDto.setDocuments(orderByDocument);
+
+			// 검색 개수와 거리를 이용해서 정렬
+			// 검색개수 가중치 : 70%, 거리 가중치 : 30%
+			float search_weight = 70;
+			float distance_weight = 30;
+			Map<Document, Float> map = new HashMap<>();
+			for(Document d : distinctNewDocuments){
+				float score;
+				int total = naverService.naverApi(d.getPlace_name());
+				double distance = Double.parseDouble(d.getDistance());
+
+				if(total < 500)
+					score =  1.0f / 3.0f * search_weight;
+				else if(total < 1000)
+					score = 2.0f / 3.0f * search_weight;
+				else
+					score = search_weight;
+
+				if(distance < Double.parseDouble(radius) / 3.0d)
+					score += distance_weight;
+				else if(distance < Double.parseDouble(radius) * 2.0d / 3.0d)
+					score += 2.0f / 3.0f * distance_weight;
+				else
+					score += 1.0f / 3.0f * distance_weight;
+
+				map.put(d, score);
+				TimeUnit.MILLISECONDS.sleep(50); //FIXME '429 Too Many Requests'에 대한 해결책
+			}
+
+			List<Document> keySetList = new ArrayList<>(map.keySet());
+
+			Collections.sort(keySetList, (o1, o2) -> (map.get(o2).compareTo(map.get(o1))));
+
+			if(keySetList.size() > Integer.parseInt(round)){
+				keySetList = keySetList.subList(0, Integer.parseInt(round));
+			}
+
+			newKakaoResponseDto.setDocuments(keySetList);
 			newKakaoResponseDto.setMeta(kakaoResponseDto.meta);
 		} catch(Exception e) {
 			throw e;
 		}
 		return new ResponseEntity<KakaoResponseDto>(newKakaoResponseDto, headers, HttpStatus.valueOf(200));
 	}
-	
-	public void foodClassification(KakaoResponseDto kakaoResponseDto, String food) throws Exception {
+
+	public void foodClassification(KakaoResponseDto kakaoResponseDto, String food) {
 		List<Document> documents = kakaoResponseDto.documents;
 		try {
-//			for(Document document : documents) {
-//				if(food.equals("국밥,감자탕")){
-//					if(document.category_name.contains("국밥") || document.category_name.contains("감자탕")){
-//						newDocuments.add(document);
-//					}
-//				}
-//				else if(food.equals("바")){
-//					if(document.category_name.contains("와인바") || document.category_name.contains("오뎅바")
-//							|| document.category_name.contains("칵테일바")){
-//						newDocuments.add(document);
-//					}
-//				}
-//				else if(food.equals("기타")){
-//					if(document.category_name.contains("실내포장마차") || document.category_name.contains("일본식주점")){
-//						newDocuments.add(document);
-//					}
-//				}
-//				else if(document.category_name.contains(food)){
-//					newDocuments.add(document);
-//				}
-//			}
-			int count = 1;
 			for(Document document : documents) {
-				String category_name = document.category_name.replace(" ", "").split(">")[1];
-
-				if(category_name.equals(food)) {
-					newDocuments.add(document);
-					dinignCodeService.dinignCodeCrawling(document);
-					System.err.println("갯수 : " + count);
-					count++;
+				if(food.equals("국밥,감자탕")){
+					if(document.category_name.contains("국밥") || document.category_name.contains("감자탕")){
+						newDocuments.add(document);
+					}
 				}
-				
-				if(count == 16) {
-					break;
+				else if(food.equals("바")){
+					if(document.category_name.contains("와인바") || document.category_name.contains("오뎅바")
+							|| document.category_name.contains("칵테일바")){
+						newDocuments.add(document);
+					}
+				}
+				else if(food.equals("기타")){
+					if(document.category_name.contains("실내포장마차") || document.category_name.contains("일본식주점")){
+						newDocuments.add(document);
+					}
+				}
+				else if(document.category_name.contains(food)){
+					newDocuments.add(document);
 				}
 			}
-			dinignCodeService.driverClose();
 		} catch(Exception e) {
 			throw e;
 		}

--- a/src/main/java/com/dnd/mountclim/domain/service/NaverService.java
+++ b/src/main/java/com/dnd/mountclim/domain/service/NaverService.java
@@ -1,0 +1,45 @@
+package com.dnd.mountclim.domain.service;
+
+import com.dnd.mountclim.domain.dto.NaverResponseDto;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.web.client.RestTemplate;
+
+@Service
+public class NaverService {
+
+    @Value("${naver.client.id.key}")
+    private String NAVER_API_IDKEY;
+
+    @Value("${naver.client.secret.key}")
+    private String NAVER_API_SECRETKEY;
+
+    public int naverApi(String place_name){
+        NaverResponseDto NaverResponseDto;
+        RestTemplate restTemplate = new RestTemplate();
+        HttpHeaders headers = new HttpHeaders();
+
+        try{
+            HttpEntity<String> entity = new HttpEntity<>(headers);
+
+
+            headers.set("X-Naver-Client-Id", NAVER_API_IDKEY);
+            headers.set("X-Naver-Client-Secret", NAVER_API_SECRETKEY);
+            String apiURL = "https://openapi.naver.com/v1/search/blog?"
+                    + "query=" + place_name;
+
+            ResponseEntity<NaverResponseDto> responseEntity = restTemplate.exchange(apiURL, HttpMethod.GET, entity, NaverResponseDto.class);
+            NaverResponseDto = responseEntity.getBody();
+
+            return NaverResponseDto.getTotal();
+
+
+        }catch (Exception e){
+            throw e;
+        }
+    }
+}

--- a/src/main/java/com/dnd/mountclim/domain/util/DeduplicationUtils.java
+++ b/src/main/java/com/dnd/mountclim/domain/util/DeduplicationUtils.java
@@ -1,0 +1,21 @@
+package com.dnd.mountclim.domain.util;
+
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
+
+public class DeduplicationUtils {
+    public static<T> List<T> deduplication(final List<T> list, Function<? super T, ?> key){
+        return list.stream()
+                .filter(deduplication(key))
+                .collect(Collectors.toList());
+    }
+
+    private static <T> Predicate<T> deduplication(Function<? super T, ?> key){
+        final Set<Object> set = ConcurrentHashMap.newKeySet();
+        return predicate->set.add(key.apply(predicate));
+    }
+}


### PR DESCRIPTION
## 작업사항 :thumbsup:
1. 검색량(가중치70)과 거리(가중치30)를 이용하여 정렬
2. round 개수에 맞게 반환

## 기타 :star:
1. 검색된 음식점이 round개수보다 작은 경우 일단은 부족한 만큼 데이터를 주고 있는데, 개수가 부족한 경우 어떻게 처리할 것인지에 대한 논의 필요
2. naver api에 많은 요청을 보낼경우 에러가 뜸. 그래서 각 가게의 호출마다 50milliseconds의 텀을 두고 있어서 추가적인 딜레이가 발생

