### PR TITLE
feat : 메뉴 다중선택 허용

### DIFF
--- a/src/main/java/com/dnd/mountclim/domain/service/KakaoService.java
+++ b/src/main/java/com/dnd/mountclim/domain/service/KakaoService.java
@@ -144,30 +144,33 @@ public class KakaoService {
 
 	public void foodClassification(KakaoResponseDto kakaoResponseDto, String food) {
 		List<Document> documents = kakaoResponseDto.documents;
-		try {
-			for(Document document : documents) {
-				if(food.equals("국밥,감자탕")){
-					if(document.category_name.contains("국밥") || document.category_name.contains("감자탕")){
+		List<String> foodList = Arrays.asList(food.split("\\|"));
+		for(String eachFood : foodList){
+			try {
+				for(Document document : documents) {
+					if(eachFood.equals("국밥,감자탕")){
+						if(document.category_name.contains("국밥") || document.category_name.contains("감자탕")){
+							newDocuments.add(document);
+						}
+					}
+					else if(eachFood.equals("바")){
+						if(document.category_name.contains("와인바") || document.category_name.contains("오뎅바")
+								|| document.category_name.contains("칵테일바")){
+							newDocuments.add(document);
+						}
+					}
+					else if(eachFood.equals("기타")){
+						if(document.category_name.contains("실내포장마차") || document.category_name.contains("일본식주점")){
+							newDocuments.add(document);
+						}
+					}
+					else if(document.category_name.contains(eachFood)){
 						newDocuments.add(document);
 					}
 				}
-				else if(food.equals("바")){
-					if(document.category_name.contains("와인바") || document.category_name.contains("오뎅바")
-							|| document.category_name.contains("칵테일바")){
-						newDocuments.add(document);
-					}
-				}
-				else if(food.equals("기타")){
-					if(document.category_name.contains("실내포장마차") || document.category_name.contains("일본식주점")){
-						newDocuments.add(document);
-					}
-				}
-				else if(document.category_name.contains(food)){
-					newDocuments.add(document);
-				}
+			} catch(Exception e) {
+				throw e;
 			}
-		} catch(Exception e) {
-			throw e;
 		}
 	}
 }

--- a/src/main/java/com/dnd/mountclim/domain/service/NaverService.java
+++ b/src/main/java/com/dnd/mountclim/domain/service/NaverService.java
@@ -12,10 +12,10 @@ import org.springframework.web.client.RestTemplate;
 @Service
 public class NaverService {
 
-    @Value("${naver.client.id.key}")
+    @Value("${naver.api.id.key}")
     private String NAVER_API_IDKEY;
 
-    @Value("${naver.client.secret.key}")
+    @Value("${naver.api.secret.key}")
     private String NAVER_API_SECRETKEY;
 
     public int naverApi(String place_name){

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -72,8 +72,8 @@ logging:
               BasicBinder: TRACE
 
 naver:
-  client:
-    secret:
-      key: ${naver.client.secret.key}
+  api:
     id:
-      key: ${naver.client.id.key}
+      key: ${naver.api.id.key}
+    secret:
+      key: ${naver.api.secret.key}


### PR DESCRIPTION
## 작업사항 :thumbsup:
1. 메뉴 다중 선택 허용

## 사용방법 :smiley:
1. 여러 가지 메뉴를 보낼때 ${육류,고기|해물,생선|기타}로 보내야함.
2. 음식이 한 가지일때 위에처럼 param으로 바로 보내도 되지만, 여러가지일때는 특수문자가 있어서 encodeURL(param)해서 보내야함. (무조건 encodeURL하기)

## 기타 :star:
프론트분들께 food는 encodeURL해서 보내달라고 요청하기.

